### PR TITLE
Expand README notes on endpoint formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ To run this sample, rename `.env.sample` to `.env` and populate the values for:
 > [!IMPORTANT]
 > The `AZURE_OPENAI_ENDPOINT` value should be the URL up to `/openai` but __not__ include the `/openai` part of the URL.
 > 
-> Example: If your API endpoint is something like:  
+> Example: If your API URL is something like: 
 > `https://my-apim.azure-api.net/openai/deployments/...`  
-> ... then your `AZURE_OPENAPI_ENDPOINT` should be:  
+> ... then your `AZURE_OPENAPI_ENDPOINT` should be: 
 > `https://my-apim.azure-api.net`
 
 ### Samples Available

--- a/README.md
+++ b/README.md
@@ -20,7 +20,15 @@ Note that "Open AI" endpoints are expected to end with `/openai` after the endpo
 To run this sample, rename `.env.sample` to `.env` and populate the values for:
 
 - `AZURE_OPENAI_API_KEY`: Your APIM subscription key
-- `AZURE_OPENAI_ENDPOINT`: The URL to your APIM OpenAI APIs
+- `AZURE_OPENAI_ENDPOINT`: The URL to your APIM OpenAI API
+
+> [!IMPORTANT]
+> The `AZURE_OPENAI_ENDPOINT` value should be the URL up to `/openai` but __not__ include the `/openai` part of the URL.
+> 
+> Example: If your API endpoint is something like:  
+> `https://my-apim.azure-api.net/openai/deployments/...`  
+> ... then your `AZURE_OPENAPI_ENDPOINT` should be:  
+> `https://my-apim.azure-api.net`
 
 ### Samples Available
 


### PR DESCRIPTION
This pull request includes a change to the `README.md` file. The change provides more detailed instructions on how to populate the `AZURE_OPENAI_ENDPOINT` value in the `.env` file. The instructions now specify that the URL should be up to `/openai` but not include the `/openai` part of the URL, and an example is provided for clarity.